### PR TITLE
Ensure to Pre-Load imports in main thread

### DIFF
--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -140,6 +140,17 @@ class Task:
 
             self._report_completion()
 
+        # pre-load imports in before starting a new separate Thread.
+        # in windows some imports (e.g. numpy) lead to the script get stuck if loaded in separate thread
+        block = ast.parse(script, mode='exec')
+        import_nodes = [
+            node for node in block.body
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+        ]
+        import_block = ast.Module(body=import_nodes, type_ignores=[])
+        compiled_imports = compile(import_block, filename="<imports>", mode="exec")
+        exec(compiled_imports, globals())
+
         # Create a thread and save a reference to it, in case its script
         # ends up killing the thread. This happens e.g. if it calls sys.exit.
         self.thread = Thread(target=execute_script, name=f"Appose-{self.uuid}")

--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -141,7 +141,8 @@ class Task:
             self._report_completion()
 
         # pre-load imports in before starting a new separate Thread.
-        # in windows some imports (e.g. numpy) lead to the script get stuck if loaded in separate thread
+        # in windows some imports (e.g. numpy) lead to the script 
+        # get stuck if loaded in separate thread
         block = ast.parse(script, mode='exec')
         import_nodes = [
             node for node in block.body


### PR DESCRIPTION
This draft PR is a suggestion to fix https://github.com/apposed/appose/issues/13

This is issue was really difficult to debug. As already found and communiated, it only can be reproduced in Windows environments. It could not be reproduced in Linux. Situation on Mac is unclear (not yet tested on Mac), cf: https://github.com/apposed/appose/issues/13#issuecomment-2797253191

I tried to reproduce on Windows from the command line using the env from this code example (https://github.com/apposed/appose/issues/13#issue-2976746878) and the following command
```
micromamba run -p C:\Users\xxxx\.local\share\appose\stardist C:\Users\xxxx\.local\share\appose\stardist\python.exe -c "import appose.python_worker; appose.python_worker.main()"
```

and then interactively inputing this task to `stdin`

```
{"task":"c388f270-d6be-48df-9e02-e42b48cab98b","requestType":"EXECUTE","inputs":{},"script":"import numpy\n"}
```

This results in a perfectly working process:

```
[SERVICE-0] {"task":"c388f270-d6be-48df-9e02-e42b48cab98b","requestType":"EXECUTE","inputs":{},"script":"import numpy\n"}
[SERVICE-0] {"task":"c388f270-d6be-48df-9e02-e42b48cab98b","responseType":"LAUNCH"}
[SERVICE-0] {"task":"c388f270-d6be-48df-9e02-e42b48cab98b","responseType":"COMPLETION","outputs":{}}
```

However, when I try to run this from a Java process similar to the code example (https://github.com/apposed/appose/issues/13#issue-2976746878), I only get this response and then the whole process is stuck in a dead lock:

```
[SERVICE-0] {"task":"c388f270-d6be-48df-9e02-e42b48cab98b","requestType":"EXECUTE","inputs":{},"script":"import numpy\n"}
[SERVICE-0] {"task":"c388f270-d6be-48df-9e02-e42b48cab98b","responseType":"LAUNCH"}
```

The code added in this PR fixes this situation. It seems that loading imports like (e.g.) numpy can lead to deadlocks when being loaded in multiple threads.

I am not sure, if the proposed fix is a good one however. Since the problem occurs only on Windows, one could think about adding `if sys.platform == 'win32':` or something like this to only perform the extra code on Windows. Also, one could think about making this optional and controlable from outside the python_worker by perhaps only performing the new code, if some global variable is set.

@ctrueden curious to learn your opinion about this.